### PR TITLE
feat: 新增图像列表，不再需要一次选好所有的图像，并且可以自行重新排序；标题图像现在可以复用已上传的图像；修复了不同比例界面样式不一致…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-icons/vue": "^1.0.0",
+    "@types/sortablejs": "^1.15.8",
     "@vueuse/core": "^12.0.0",
     "@vueuse/integrations": "^12.0.0",
     "circletype": "^2.3.0",
@@ -21,6 +22,7 @@
     "pinia": "^2.2.6",
     "qrcode": "^1",
     "radix-vue": "^1.9.10",
+    "sortablejs": "^1.15.6",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "tailwindcss-gradients": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,15 @@ importers:
       '@radix-icons/vue':
         specifier: ^1.0.0
         version: 1.0.0(vue@3.5.13)
+      '@types/sortablejs':
+        specifier: ^1.15.8
+        version: 1.15.8
       '@vueuse/core':
         specifier: ^12.0.0
         version: 12.0.0
       '@vueuse/integrations':
         specifier: ^12.0.0
-        version: 12.0.0(async-validator@4.2.5)(qrcode@1.5.4)
+        version: 12.0.0(async-validator@4.2.5)(qrcode@1.5.4)(sortablejs@1.15.6)
       circletype:
         specifier: ^2.3.0
         version: 2.3.0
@@ -44,6 +47,9 @@ importers:
       radix-vue:
         specifier: ^1.9.10
         version: 1.9.11(vue@3.5.13)
+      sortablejs:
+        specifier: ^1.15.6
+        version: 1.15.6
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.5.5
@@ -590,6 +596,9 @@ packages:
 
   '@types/node@22.10.2':
     resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+
+  '@types/sortablejs@1.15.8':
+    resolution: {integrity: sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==}
 
   '@types/web-bluetooth@0.0.16':
     resolution: {integrity: sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ==}
@@ -1479,6 +1488,9 @@ packages:
     resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
     engines: {node: '>=18'}
 
+  sortablejs@1.15.6:
+    resolution: {integrity: sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2180,6 +2192,8 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
+  '@types/sortablejs@1.15.8': {}
+
   '@types/web-bluetooth@0.0.16': {}
 
   '@types/web-bluetooth@0.0.20': {}
@@ -2343,7 +2357,7 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/integrations@12.0.0(async-validator@4.2.5)(qrcode@1.5.4)':
+  '@vueuse/integrations@12.0.0(async-validator@4.2.5)(qrcode@1.5.4)(sortablejs@1.15.6)':
     dependencies:
       '@vueuse/core': 12.0.0
       '@vueuse/shared': 12.0.0
@@ -2351,6 +2365,7 @@ snapshots:
     optionalDependencies:
       async-validator: 4.2.5
       qrcode: 1.5.4
+      sortablejs: 1.15.6
     transitivePeerDependencies:
       - typescript
 
@@ -3086,6 +3101,8 @@ snapshots:
       '@polka/url': 1.0.0-next.28
       mrmime: 2.0.0
       totalist: 3.0.1
+
+  sortablejs@1.15.6: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/components/DisplayContent.vue
+++ b/src/components/DisplayContent.vue
@@ -1,6 +1,7 @@
 <template>
     <div ref="displaySection"
-        :class="['w-full', 'min-h-[200px]', 'pattern-grid-md', backgroundConfig.bgClass, backgroundConfig.patternClass]">
+        :class="['w-full', 'pattern-grid-md', backgroundConfig.bgClass, backgroundConfig.patternClass]"
+        style="min-height: auto;">
         <!--顶部-->
         <div class="grid grid-cols-4 gap-4 min-h-[200px] pt-4 px-4">
             <div class="w-full">

--- a/src/components/ImageListManager.vue
+++ b/src/components/ImageListManager.vue
@@ -1,0 +1,405 @@
+<template>
+  <div class="w-full">
+    <div class="text-[20px] font-bold mb-3">图片管理</div>
+    
+    <!-- 上传区域 -->
+    <div class="mb-4">
+      <div class="mb-2">添加图片</div>
+      <div class="flex items-center gap-2">
+        <el-button @click="triggerFileInput" type="primary">
+          选择图片
+        </el-button>
+        <input 
+          ref="fileInput" 
+          accept="image/*" 
+          @change="handleFileAdd" 
+          type="file" 
+          multiple 
+          class="hidden"
+        />
+        <el-button v-if="uploadedFiles.length > 0" @click="clearAllFiles" type="danger">
+          清空全部
+        </el-button>
+      </div>
+    </div>
+
+    <!-- 图片列表 -->
+    <div v-if="uploadedFiles.length > 0" class="mb-4">
+      <div class="mb-2">图片列表（{{ uploadedFiles.length }}张）</div>
+      <div class="text-xs text-gray-500 mb-2">可拖拽排序，影响展示图中的显示顺序</div>
+      
+      <div 
+        ref="listContainer"
+        class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-2 gap-3 image-list-container border rounded-lg p-3 bg-gray-50 narrow-screen-single-col"
+      >
+        <div 
+          v-for="(file, index) in uploadedFiles" 
+          :key="file.id"
+          class="relative group cursor-move border-2 border-dashed border-gray-300 rounded-lg overflow-hidden hover:border-blue-400 transition-colors image-item"
+          :class="{ 'border-blue-500 bg-blue-50': selectedTitleFromList === file.id }"
+        >
+          <!-- 图片预览 -->
+          <div class="aspect-square relative">
+            <img 
+              :src="file.url" 
+              :alt="file.name" 
+              class="w-full h-full object-cover"
+            />
+            
+            <!-- 遮罩层 -->
+            <div class="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-30 md:group-hover:bg-opacity-30 transition-all duration-200 flex items-center justify-center">
+              <div class="opacity-0 group-hover:opacity-100 md:opacity-0 md:group-hover:opacity-100 sm:opacity-100 flex gap-1 transition-opacity">
+                <!-- 设为标题按钮 -->
+                <el-button 
+                  @click.stop="setAsTitle(file.id)"
+                  @mousedown.stop
+                  @touchstart.stop
+                  size="small"
+                  :type="selectedTitleFromList === file.id ? 'primary' : 'default'"
+                  class="text-xs"
+                >
+                  {{ selectedTitleFromList === file.id ? '已选' : '标题' }}
+                </el-button>
+                <!-- 删除按钮 -->
+                <el-button 
+                  @click.stop="removeFile(file.id)"
+                  @mousedown.stop
+                  @touchstart.stop
+                  size="small"
+                  type="danger"
+                  class="text-xs"
+                >
+                  删除
+                </el-button>
+              </div>
+            </div>
+
+            <!-- 标题标识 -->
+            <div 
+              v-if="selectedTitleFromList === file.id" 
+              class="absolute top-1 right-1 bg-blue-600 text-white text-xs px-1 rounded"
+            >
+              标题
+            </div>
+
+            <!-- 序号 -->
+            <div class="absolute top-1 left-1 bg-black bg-opacity-60 text-white text-xs px-1 rounded">
+              {{ index + 1 }}
+            </div>
+          </div>
+
+          <!-- 文件名 -->
+          <div class="p-1 text-xs text-gray-600 truncate bg-white" :title="file.name">
+            {{ file.name }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 标题选择区域 -->
+    <div class="mb-4">
+      <div class="text-[18px] font-semibold mb-2">标题表情包</div>
+      <div class="text-sm text-gray-600 mb-2">
+        可以从图片列表中选择作为标题，或单独上传标题图片
+      </div>
+      
+      <!-- 当前标题显示 -->
+      <div v-if="currentTitlePhoto" class="mb-3 p-3 border rounded-lg bg-blue-50">
+        <div class="text-sm font-medium mb-2">当前标题图片：</div>
+        <div class="flex items-center gap-3">
+          <img 
+            :src="currentTitlePhoto.url" 
+            :alt="currentTitlePhoto.name" 
+            class="w-16 h-16 object-cover rounded border"
+          />
+          <div class="flex-1">
+            <div class="text-sm font-medium">{{ currentTitlePhoto.name }}</div>
+            <div class="text-xs text-gray-500">
+              {{ selectedTitleFromList ? '来源：图片列表' : '来源：单独上传' }}
+            </div>
+          </div>
+          <el-button @click="clearTitle" size="small" type="danger">
+            清除
+          </el-button>
+        </div>
+      </div>
+
+      <!-- 单独上传标题 -->
+      <div class="flex items-center gap-2">
+        <el-button @click="triggerTitleInput" type="primary">
+          上传标题图片
+        </el-button>
+        <input 
+          ref="titleInput" 
+          accept="image/*"
+          @change="handleTitleUpload" 
+          type="file" 
+          class="hidden"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, nextTick, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useMemeStore } from '@/stores/meme'
+import { Input } from '@/components/ui/input'
+import Sortable from 'sortablejs'
+
+const memeStore = useMemeStore()
+const { 
+  uploadedFiles, 
+  selectedTitleFromList, 
+  currentTitlePhoto
+} = storeToRefs(memeStore)
+
+const {
+  addFileToList,
+  removeFileFromList,
+  reorderFiles,
+  clearUploadedFiles,
+  setTitleFromList,
+  setTitlePhoto,
+  clearTitlePhoto
+} = memeStore
+
+const fileInput = ref(null)
+const titleInput = ref(null)
+const listContainer = ref(null)
+let sortableInstance = null
+
+// 触发文件选择
+const triggerFileInput = () => {
+  if (fileInput.value) {
+    fileInput.value.click()
+  }
+}
+
+// 触发标题文件选择
+const triggerTitleInput = () => {
+  if (titleInput.value) {
+    titleInput.value.click()
+  }
+}
+
+// 处理文件添加
+const handleFileAdd = (e) => {
+  const files = Array.from(e.target.files)
+  if (files.length > 0) {
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+    files.forEach(file => {
+      if (allowedTypes.includes(file.type)) {
+        addFileToList(file)
+      }
+    })
+    // 清空input - 修复清空问题
+    if (fileInput.value) {
+      fileInput.value.value = ''
+    }
+    // 重新初始化拖拽
+    reinitSortable()
+  }
+}
+
+// 处理标题上传
+const handleTitleUpload = (e) => {
+  const file = e.target.files[0]
+  if (file) {
+    const photo = {
+      name: file.name,
+      type: file.type,
+      url: URL.createObjectURL(file)
+    }
+    setTitlePhoto('titlePhoto1', photo)
+    // 清空input
+    if (titleInput.value) {
+      titleInput.value.value = ''
+    }
+  }
+}
+
+// 删除文件
+const removeFile = (id) => {
+  removeFileFromList(id)
+  // 重新初始化拖拽
+  reinitSortable()
+}
+
+// 清空所有文件
+const clearAllFiles = () => {
+  clearUploadedFiles()
+  if (fileInput.value) {
+    fileInput.value.value = ''
+  }
+  if (sortableInstance) {
+    sortableInstance.destroy()
+    sortableInstance = null
+  }
+}
+
+// 设为标题
+const setAsTitle = (fileId) => {
+  if (selectedTitleFromList.value === fileId) {
+    // 如果已经是标题，则取消选择
+    setTitleFromList(null)
+  } else {
+    setTitleFromList(fileId)
+  }
+}
+
+// 清除标题
+const clearTitle = () => {
+  if (selectedTitleFromList.value) {
+    setTitleFromList(null)
+  } else {
+    clearTitlePhoto('titlePhoto1')
+    if (titleInput.value) {
+      titleInput.value.value = ''
+    }
+  }
+}
+
+// 初始化拖拽排序
+const initSortable = () => {
+  if (listContainer.value && uploadedFiles.value.length > 0) {
+    if (sortableInstance) {
+      sortableInstance.destroy()
+    }
+    
+    sortableInstance = Sortable.create(listContainer.value, {
+      animation: 150,
+      ghostClass: 'sortable-ghost',
+      chosenClass: 'sortable-chosen',
+      dragClass: 'sortable-drag',
+      // 不过滤按钮，让整个图片项可拖拽
+      filter: false,
+      // 简化触屏支持
+      delay: 0,
+      delayOnTouchStart: false,
+      onEnd: (evt) => {
+        const oldIndex = evt.oldIndex
+        const newIndex = evt.newIndex
+        
+        if (oldIndex !== newIndex) {
+          const newOrder = [...uploadedFiles.value]
+          const item = newOrder.splice(oldIndex, 1)[0]
+          newOrder.splice(newIndex, 0, item)
+          reorderFiles(newOrder)
+        }
+      }
+    })
+  }
+}
+
+// 在组件挂载时初始化拖拽
+onMounted(() => {
+  nextTick(() => {
+    initSortable()
+  })
+})
+
+// 监听文件列表变化，重新初始化拖拽
+const reinitSortable = () => {
+  nextTick(() => {
+    initSortable()
+  })
+}
+
+// 监听uploadedFiles变化
+watch(uploadedFiles, () => {
+  reinitSortable()
+}, { deep: true })
+</script>
+
+<style scoped>
+.cursor-move:hover {
+  cursor: grab;
+}
+
+.cursor-move:active {
+  cursor: grabbing;
+}
+
+/* 防止拖拽时选择文本 */
+.image-item {
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+.image-item * {
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+/* 增加图片列表容器高度 */
+.image-list-container {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+/* 响应式调整 */
+@media (max-width: 768px) {
+  .image-list-container {
+    max-height: 50vh;
+  }
+}
+
+/* 特别窄屏（小于480px）显示1列 */
+@media (max-width: 479px) {
+  .narrow-screen-single-col {
+    grid-template-columns: 1fr;
+    column-gap: 4rem; /* 横向64px */
+    row-gap: 0.75rem; /* 纵向12px */
+    padding-left: 2rem; /* 左侧空白32px */
+    padding-right: 2rem; /* 右侧空白32px */
+  }
+}
+
+/* 小于1024px都用大横向间距 */
+@media (max-width: 1023px) {
+  .narrow-screen-single-col {
+    column-gap: 4rem; /* 横向64px */
+    row-gap: 0.75rem; /* 纵向12px */
+  }
+}
+
+/* 滚动条样式 */
+.image-list-container::-webkit-scrollbar {
+  width: 8px;
+}
+
+.image-list-container::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 4px;
+}
+
+.image-list-container::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 4px;
+}
+
+.image-list-container::-webkit-scrollbar-thumb:hover {
+  background: #a8a8a8;
+}
+
+/* Sortable样式 */
+:global(.sortable-ghost) {
+  opacity: 0.5;
+  transform: scale(0.95);
+}
+
+:global(.sortable-chosen) {
+  transform: scale(1.05);
+  z-index: 999;
+}
+
+:global(.sortable-drag) {
+  transform: rotate(5deg);
+}
+</style>

--- a/src/components/WaterMark.vue
+++ b/src/components/WaterMark.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="watermark-wrapper">
+  <div class="watermark-wrapper" ref="wrapperRef">
     <slot></slot>
     <div class="watermark-container" v-if="imageCount > 0 && image">
       <img
@@ -15,8 +15,8 @@
 </template>
 
 <script lang="js" setup>
-import { computed, onMounted, onBeforeUnmount } from 'vue'
-import { useWindowSize } from '@vueuse/core'
+import { computed, onMounted, onBeforeUnmount, ref, nextTick } from 'vue'
+import { useElementSize } from '@vueuse/core'
 
 const props = defineProps({
     image: {
@@ -49,16 +49,18 @@ const props = defineProps({
     }
 })
 
-const { width: windowWidth, height: windowHeight } = useWindowSize()
+const wrapperRef = ref(null)
+
+// 使用容器大小而不是窗口大小
+const { width: containerWidth, height: containerHeight } = useElementSize(wrapperRef)
 
 const cols = computed(() => {
-  return Math.ceil(windowWidth.value / (props.width + props.gap[0]))
+  return Math.ceil(containerWidth.value / (props.width + props.gap[0]))
 })
 
-
 const getImageCount = () => {
-  const cols = Math.ceil(windowWidth.value / (props.width + props.gap[0]))
-  const rows = Math.ceil(windowHeight.value / (props.height + props.gap[1]))
+  const cols = Math.ceil(containerWidth.value / (props.width + props.gap[0]))
+  const rows = Math.ceil(containerHeight.value / (props.height + props.gap[1]))
   return cols * rows
 }
 

--- a/src/pages/theme/theme1.vue
+++ b/src/pages/theme/theme1.vue
@@ -62,6 +62,21 @@
               <label class="block text-sm font-medium mb-2">文字大小: {{ TextSize }}px</label>
               <el-slider v-model="TextSize" :min="1" :max="50"></el-slider>
             </div>
+            
+            <div>
+              <label class="block text-sm font-medium mb-2">字体选择</label>
+              <el-select v-model="selectedFont" placeholder="选择字体" class="w-full">
+                <el-option
+                  v-for="font in fontOptions"
+                  :key="font.value"
+                  :label="font.label"
+                  :value="font.value"
+                  :style="{ fontFamily: font.family }"
+                >
+                  {{ font.label }}
+                </el-option>
+              </el-select>
+            </div>
           </div>
         </div>
         <!-- 水印设置 -->
@@ -153,7 +168,8 @@
     <!--展示-->
     <div class="lg:w-2/3 w-full flex items-start justify-center bg-gray-50 p-4">
       <div 
-        class="preview-wrapper font-[MaiYuan]" 
+        class="preview-wrapper"
+        :class="currentFontClass"
         :style="wrapperStyle"
       >
         <div class="preview-content" :style="contentStyle" id="display-section">
@@ -216,6 +232,30 @@ const {
   presetBackgroundColors,
   selectedBackgroundIndex
 } = storeToRefs(memeStore)
+
+// 字体选择相关
+const selectedFont = ref('MaiYuan')
+const fontOptions = [
+  { label: '荆南麦圆体 (MaiYuan)', value: 'MaiYuan', family: 'MaiYuan' },
+  { label: '禅圆体 (Maru)', value: 'Maru', family: 'Maru' },
+  { label: '汤圆体 (TangYuan)', value: 'tangyuan', family: 'tangyuan' },
+  { label: '系统默认 (无衬线)', value: 'system', family: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif' },
+  { label: '微软雅黑', value: 'microsoft', family: 'Microsoft YaHei, sans-serif' },
+  { label: '宋体 (衬线)', value: 'serif', family: 'SimSun, serif' }
+]
+
+// 计算当前字体类名
+const currentFontClass = computed(() => {
+  const fontMap = {
+    'MaiYuan': 'font-[MaiYuan]',
+    'Maru': 'font-[Maru]', 
+    'tangyuan': 'font-[tangyuan]',
+    'system': 'font-sans',
+    'microsoft': 'font-[Microsoft_YaHei]',
+    'serif': 'font-serif'
+  }
+  return fontMap[selectedFont.value] || 'font-[MaiYuan]'
+})
 
 
 

--- a/src/pages/theme/theme1.vue
+++ b/src/pages/theme/theme1.vue
@@ -1,103 +1,179 @@
 <template>
   <div class="flex h-full lg:flex-row flex-col-reverse max-w-[1100px] w-full flex-grow m-5 rounded-md">
-    <!--控件-->
-    <div class="lg:w-1/3 w-full h-full flex-grow lg:mr-4 lg:mt-0 mt-4 bg-white p-5 sticky">
-      <div class="grid w-full max-w-sm items-center gap-1.5">
-        <div class="text-[20px] font-bold">上传文件</div>
-        <div>上传图片</div>
-        <div class="w-full flex flex-row flex-nowrap items-center">
-          <Input ref="fileInput" accept="image/*" @change="handleFileChange" id="picture" type="file" multiple />
-          <el-button class="ml-2" v-if="uploadedFiles.length > 0" @click="cleanFiles">删除</el-button>
-        </div>
-        <div>标题表情包</div>
-        <div class="w-full flex flex-row flex-nowrap items-center">
-          <Input ref="photoInput1" class="w-full" accept="image/*"
-            @change="handleTitleFileChange($event, 'titlePhoto1')" id="titlePhoto1" type="file" :multiple="false" />
-          <el-button class="ml-2" v-if="titlePhoto1" @click="cleanPhoto1">删除</el-button>
-        </div>
-        <!-- <div>标题表情包2</div>
-        <div class="w-full flex flex-row flex-nowrap items-center">
-          <Input ref="photoInput2" class="w-full" accept="image/*"
-            @change="handleTitleFileChange($event, 'titlePhoto2')" id="titlePhoto2" type="file" :multiple="false" />
-          <el-button class="ml-2" v-if="titlePhoto2" @click="cleanPhoto2">删除</el-button>
-        </div> -->
-        <div class="text-[20px] font-bold">补充信息</div>
-        <div>表情包名称</div>
-        <el-input v-model="MemeName" placeholder="请输入表情包名称" clearable></el-input>
-        <div>画师名称</div>
-        <el-input v-model="ArtistName" placeholder="请输入画师名称" clearable></el-input>
-
-        <div>背景颜色</div>
-        <div class="grid grid-cols-5 gap-2 mb-3">
-          <div v-for="(preset, index) in presetBackgroundColors" :key="preset.name"
-            @click="selectBackgroundColor(preset, index)" :class="[
-              'w-12 h-12 rounded-lg cursor-pointer border-2 transition-all duration-200 hover:scale-110 relative group',
-              preset.bgClass,
-              selectedBackgroundIndex === index ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-300 hover:border-gray-400'
-            ]" :title="preset.name">
-            <!-- 选中状态的勾号 -->
-            <div v-if="selectedBackgroundIndex === index"
-              class="absolute inset-0 flex items-center justify-center text-white text-lg font-bold drop-shadow-lg">
-              ✓
+    <!-- 左侧控制面板 -->
+    <div class="lg:w-1/3 w-full h-full flex-grow lg:mr-4 lg:mt-0 mt-4 bg-white p-5 overflow-y-auto">
+      <div class="p-4 space-y-6">
+        
+        <!-- 图片管理组件 -->
+        <ImageListManager />
+        
+        <!-- 分割线 -->
+        <div class="border-t border-gray-200"></div>
+        <!-- 基本信息 -->
+        <div class="space-y-4">
+          <div class="text-[20px] font-bold">基本信息</div>
+          <div class="space-y-3">
+            <div>
+              <label class="block text-sm font-medium mb-1">表情包名称</label>
+              <el-input v-model="MemeName" placeholder="请输入表情包名称" clearable></el-input>
             </div>
-            <!-- 悬停时显示颜色名称 -->
-            <div
-              class="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10">
-              {{ preset.name }}
+            <div>
+              <label class="block text-sm font-medium mb-1">画师名称</label>
+              <el-input v-model="ArtistName" placeholder="请输入画师名称" clearable></el-input>
             </div>
           </div>
         </div>
-        <div class="flex flex-row items-center">
-          <div class="mr-3">文字颜色</div>
-          <el-color-picker v-model="TextColor" show-alpha :predefine="predefineColors" />
+
+        <!-- 样式设置 -->
+        <div class="space-y-4">
+          <div class="text-[20px] font-bold">样式设置</div>
+          <div class="space-y-4">
+            <div>
+              <label class="block text-sm font-medium mb-2">背景颜色</label>
+              <div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
+                <div v-for="(preset, index) in presetBackgroundColors" :key="preset.name"
+                  @click="selectBackgroundColor(preset, index)" :class="[
+                    'w-12 h-12 rounded-lg cursor-pointer border-2 transition-all duration-200 hover:scale-110 relative group',
+                    preset.bgClass,
+                    selectedBackgroundIndex === index ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-300 hover:border-gray-400'
+                  ]" :title="preset.name">
+                  <!-- 选中状态的勾号 -->
+                  <div v-if="selectedBackgroundIndex === index"
+                    class="absolute inset-0 flex items-center justify-center text-white text-lg font-bold drop-shadow-lg">
+                    ✓
+                  </div>
+                  <!-- 悬停时显示颜色名称 -->
+                  <div
+                    class="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10">
+                    {{ preset.name }}
+                  </div>
+                </div>
+              </div>
+            </div>
+            
+            <div class="flex flex-col space-y-2">
+              <div class="flex items-center justify-between">
+                <label class="block text-sm font-medium">文字颜色</label>
+                <el-color-picker v-model="TextColor" show-alpha :predefine="predefineColors" />
+              </div>
+            </div>
+            
+            <div>
+              <label class="block text-sm font-medium mb-2">文字大小: {{ TextSize }}px</label>
+              <el-slider v-model="TextSize" :min="1" :max="50"></el-slider>
+            </div>
+          </div>
         </div>
-        <div>文字大小</div>
-        <el-slider v-model="TextSize" :min="1" :max="50"></el-slider>
-        <div class="text-[20px] font-bold">水印</div>
-        <div>开启水印</div>
-        <el-switch v-model="enableWatermark" active-color="#13ce66" />
-        <div v-if="enableWatermark" class="flex flex-col">
-          <div>上传水印</div>
-          <Input accept="image/*" @change="handleTitleFileChange($event, 'watermark')" id="watermark" type="file"
-            :multiple="false" />
-          <div>水印间距</div>
-          X：<el-slider v-model="watermarkConfig.gap[0]"></el-slider>
-          Y：<el-slider v-model="watermarkConfig.gap[1]"></el-slider>
-          <div>水印大小</div>
-          宽度：<el-slider v-model="watermarkConfig.width" :min="1" :max="100"></el-slider>
-          高度：<el-slider v-model="watermarkConfig.height" :min="1" :max="100"></el-slider>
-          <div>不透明度</div>
-          <el-slider v-model="watermarkConfig.opacity" :min="0" :max="1" :step="0.01"></el-slider>
-          <div>水印角度</div>
-          <el-slider v-model="watermarkConfig.angle" :min="-180" :max="180"></el-slider>
+        <!-- 水印设置 -->
+        <div class="space-y-4">
+          <div class="text-[20px] font-bold">水印设置</div>
+          <div class="space-y-3">
+            <div class="flex items-center justify-between">
+              <label class="text-sm font-medium">开启水印</label>
+              <el-switch v-model="enableWatermark" active-color="#13ce66" />
+            </div>
+            
+            <div v-if="enableWatermark" class="space-y-3 pl-4 border-l-2 border-blue-200">
+              <div>
+                <label class="block text-sm font-medium mb-1">上传水印图片</label>
+                <Input accept="image/*" @change="handleTitleFileChange($event, 'watermark')" id="watermark" type="file" :multiple="false" />
+              </div>
+              
+              <div>
+                <label class="block text-sm font-medium mb-1">水印间距</label>
+                <div class="space-y-2">
+                  <div>
+                    <span class="text-xs">X轴: {{ watermarkConfig.gap[0] }}</span>
+                    <el-slider v-model="watermarkConfig.gap[0]" :min="10" :max="200"></el-slider>
+                  </div>
+                  <div>
+                    <span class="text-xs">Y轴: {{ watermarkConfig.gap[1] }}</span>
+                    <el-slider v-model="watermarkConfig.gap[1]" :min="10" :max="200"></el-slider>
+                  </div>
+                </div>
+              </div>
+              
+              <div>
+                <label class="block text-sm font-medium mb-1">水印大小</label>
+                <div class="space-y-2">
+                  <div>
+                    <span class="text-xs">宽度: {{ watermarkConfig.width }}</span>
+                    <el-slider v-model="watermarkConfig.width" :min="10" :max="150"></el-slider>
+                  </div>
+                  <div>
+                    <span class="text-xs">高度: {{ watermarkConfig.height }}</span>
+                    <el-slider v-model="watermarkConfig.height" :min="10" :max="150"></el-slider>
+                  </div>
+                </div>
+              </div>
+              
+              <div>
+                <label class="block text-sm font-medium mb-1">不透明度: {{ (watermarkConfig.opacity * 100).toFixed(0) }}%</label>
+                <el-slider v-model="watermarkConfig.opacity" :min="0" :max="1" :step="0.01"></el-slider>
+              </div>
+              
+              <div>
+                <label class="block text-sm font-medium mb-1">水印角度: {{ watermarkConfig.angle }}°</label>
+                <el-slider v-model="watermarkConfig.angle" :min="-180" :max="180"></el-slider>
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="text-[20px] font-bold">二维码</div>
-        <div>开启二维码</div>
-        <el-switch v-model="enableQRcode" active-color="#13ce66" />
-        <div v-if="enableQRcode">
-          <div>二维码链接</div>
-          <el-input v-model="QRtext" placeholder="请输入二维码链接"></el-input>
+
+        <!-- 二维码设置 -->
+        <div class="space-y-4">
+          <div class="text-[20px] font-bold">二维码设置</div>
+          <div class="space-y-3">
+            <div class="flex items-center justify-between">
+              <label class="text-sm font-medium">开启二维码</label>
+              <el-switch v-model="enableQRcode" active-color="#13ce66" />
+            </div>
+            
+            <div v-if="enableQRcode" class="pl-4 border-l-2 border-blue-200">
+              <label class="block text-sm font-medium mb-1">二维码链接</label>
+              <el-input v-model="QRtext" placeholder="请输入二维码链接"></el-input>
+            </div>
+          </div>
+        </div>
+
+        <!-- 操作按钮 -->
+        <div class="sticky bottom-0 bg-white pt-4 border-t border-gray-200">
+          <el-button 
+            class="w-full" 
+            type="primary" 
+            size="large"
+            @click="downloadImage"
+            :disabled="uploadedFiles.length === 0"
+          >
+            生成展示图
+          </el-button>
         </div>
       </div>
-      <el-button class="mt-5" @click="downloadImage">生成展示图</el-button>
     </div>
     <!--展示-->
-    <div class="lg:w-2/3 w-full h-full font-[MaiYuan]" id="display-section">
-      <WaterMark v-if="enableWatermark" class="w-full flex flex-col h-full relative overflow-hidden"
-        :image="watermarkConfig.image" :opacity="watermarkConfig.opacity" :z-index="watermarkConfig.zIndex"
-        :gap="watermarkConfig.gap" :width="watermarkConfig.width" :height="watermarkConfig.height"
-        :angle="watermarkConfig.angle">
-        <DisplayContent ref="displayContentRef" :uploadedFiles="uploadedFiles" :titlePhoto1="titlePhoto1"
-          :titlePhoto2="titlePhoto2" :MemeName="MemeName" :ArtistName="ArtistName"
-          :TextColor="TextColor" :TextSize="TextSize" :enableQRcode="enableQRcode" :QRtext="QRtext"
-          :backgroundConfig="backgroundConfig" />
-      </WaterMark>
+    <div class="lg:w-2/3 w-full flex items-start justify-center bg-gray-50 p-4">
+      <div 
+        class="preview-wrapper font-[MaiYuan]" 
+        :style="wrapperStyle"
+      >
+        <div class="preview-content" :style="contentStyle" id="display-section">
+          <WaterMark v-if="enableWatermark" class="w-full relative overflow-hidden"
+            :image="watermarkConfig.image" :opacity="watermarkConfig.opacity" :z-index="watermarkConfig.zIndex"
+            :gap="watermarkConfig.gap" :width="watermarkConfig.width" :height="watermarkConfig.height"
+            :angle="watermarkConfig.angle">
+            <DisplayContent ref="displayContentRef" :uploadedFiles="uploadedFiles" :titlePhoto1="currentTitlePhoto"
+              :titlePhoto2="titlePhoto2" :MemeName="MemeName" :ArtistName="ArtistName"
+              :TextColor="TextColor" :TextSize="TextSize" :enableQRcode="enableQRcode" :QRtext="QRtext"
+              :backgroundConfig="backgroundConfig" />
+          </WaterMark>
 
-      <div class="w-full flex flex-col h-full relative" v-else>
-        <DisplayContent ref="displayContentRef" :uploadedFiles="uploadedFiles" :titlePhoto1="titlePhoto1"
-          :titlePhoto2="titlePhoto2" :MemeName="MemeName" :ArtistName="ArtistName"
-          :TextColor="TextColor" :TextSize="TextSize" :enableQRcode="enableQRcode" :QRtext="QRtext"
-          :backgroundConfig="backgroundConfig" />
+          <div class="w-full relative" v-else>
+            <DisplayContent ref="displayContentRef" :uploadedFiles="uploadedFiles" :titlePhoto1="currentTitlePhoto"
+              :titlePhoto2="titlePhoto2" :MemeName="MemeName" :ArtistName="ArtistName"
+              :TextColor="TextColor" :TextSize="TextSize" :enableQRcode="enableQRcode" :QRtext="QRtext"
+              :backgroundConfig="backgroundConfig" />
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -107,13 +183,14 @@ import { toast } from 'vue-sonner'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import BreadCrumb from '@/components/BreadCrumb.vue';
-import { ref, reactive, computed, watchEffect } from 'vue'
+import { ref, reactive, computed, watchEffect, nextTick, onMounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useMemeStore } from '@/stores/meme'
 import { useWindowSize } from '@vueuse/core'
 import { useQRCode } from '@vueuse/integrations/useQRCode'
 import WaterMark from '@/components/WaterMark.vue';
 import DisplayContent from '@/components/DisplayContent.vue';
+import ImageListManager from '@/components/ImageListManager.vue';
 import { toPng } from 'html-to-image';
 
 const { width, height } = useWindowSize()
@@ -126,6 +203,7 @@ const {
   uploadedFiles,
   titlePhoto1,
   titlePhoto2,
+  currentTitlePhoto,
   memeName: MemeName,
   artistName: ArtistName,
   textColor: TextColor,
@@ -139,11 +217,59 @@ const {
   selectedBackgroundIndex
 } = storeToRefs(memeStore)
 
+
+
 // 根据当前背景颜色获取对应的 Tailwind 类配置
 const backgroundConfig = computed(() => {
   // 直接使用 store 中当前选择的背景配置
   const currentConfig = presetBackgroundColors.value[selectedBackgroundIndex.value]
   return currentConfig || presetBackgroundColors.value[0]
+})
+
+// 预览容器 - 固定800px宽度，整体缩放适应屏幕
+const PREVIEW_WIDTH = 800   // 固定预览宽度800px
+
+// 计算缩放和包装器样式
+const scale = computed(() => {
+  // 简化计算：直接使用实际的预览区域宽度
+  // 考虑到整体容器max-w-[1100px]的限制
+  const containerMaxWidth = 1100
+  const actualContainerWidth = Math.min(width.value, containerMaxWidth)
+  
+  let availableWidth
+  if (width.value >= 1024) {
+    // lg及以上：预览区域占2/3，但需要减去左侧面板和间距
+    availableWidth = (actualContainerWidth * 2 / 3) - 40 // 减去padding和margin
+  } else {
+    // 小屏幕：预览区域占全宽度
+    availableWidth = actualContainerWidth - 40
+  }
+  
+  // 确保不会过小，最小缩放到0.3
+  return Math.max(Math.min(availableWidth / PREVIEW_WIDTH, 1), 0.3)
+})
+
+// 获取实际内容高度（需要等DOM渲染完成）
+const actualHeight = ref(0)
+
+// 包装器样式 - 控制缩放后的占用空间
+const wrapperStyle = computed(() => {
+  return {
+    width: `${PREVIEW_WIDTH * scale.value}px`,
+    // 如果有实际高度，使用缩放后的高度；否则使用auto
+    height: actualHeight.value > 0 ? `${actualHeight.value * scale.value}px` : 'auto',
+    margin: '0 auto', // 水平居中
+    overflow: 'visible'
+  }
+})
+
+// 内容样式 - 固定800px宽度然后缩放
+const contentStyle = computed(() => {
+  return {
+    width: `${PREVIEW_WIDTH}px`,
+    transform: `scale(${scale.value})`,
+    transformOrigin: 'top left'
+  }
 })
 
 // 选择背景颜色
@@ -152,43 +278,7 @@ const selectBackgroundColor = (preset, index) => {
   memeStore.setBackgroundIndex(index)
 }
 
-let fileInput = ref(null)
-let photoInput1 = ref(null)
-let photoInput2 = ref(null)
-
-const handleFileChange = (e) => {
-  let files = Array.from(e.target.files)
-  if (files) {
-    const allowedTypes = ['image/png', 'image/jpeg', 'image/gif']
-    const processedFiles = files
-      .filter(file => allowedTypes.includes(file.type))
-      .map(file => ({
-        name: file.name,
-        type: file.type,
-        url: URL.createObjectURL(file)
-      }))
-    memeStore.setUploadedFiles(processedFiles)
-  } else {
-    memeStore.clearUploadedFiles()
-  }
-}
-
-const cleanFiles = () => {
-  memeStore.clearUploadedFiles()
-  fileInput.value.input.value = ''//清空input已选择的文件
-}
-
-const cleanPhoto1 = () => {
-  memeStore.clearTitlePhoto('titlePhoto1')
-  photoInput1.value.input.value = ''//清空input已选择的文件
-}
-
-const cleanPhoto2 = () => {
-  memeStore.clearTitlePhoto('titlePhoto2')
-  photoInput2.value.input.value = ''//清空input已选择的文件
-}
-
-// 处理上传的标题图片和水印
+// 处理水印上传
 const handleTitleFileChange = (event, photoType) => {
   const file = event.target.files[0]
   if (file) {
@@ -197,31 +287,74 @@ const handleTitleFileChange = (event, photoType) => {
       type: file.type,
       url: URL.createObjectURL(file)
     }
-    if (photoType === 'titlePhoto1') {
-      memeStore.setTitlePhoto('titlePhoto1', photo)
-    } else if (photoType === 'titlePhoto2') {
-      memeStore.setTitlePhoto('titlePhoto2', photo)
-    } else if (photoType === 'watermark') {
+    if (photoType === 'watermark') {
       memeStore.setWatermarkImage(photo.url) // 直接赋值URL字符串
     }
   }
 }
 
-//保存图片
+// 保存图片
 const displayContentRef = ref(null);
 
-const downloadImage = () => {
+// 更新实际高度
+const updateActualHeight = () => {
+  nextTick(() => {
+    if (displayContentRef.value && displayContentRef.value.displaySection) {
+      actualHeight.value = displayContentRef.value.displaySection.offsetHeight
+    }
+  })
+}
+
+// 监听内容变化，更新高度
+watchEffect(() => {
+  // 当uploadedFiles变化时，重新计算高度
+  uploadedFiles.value
+  updateActualHeight()
+})
+
+onMounted(() => {
+  updateActualHeight()
+})
+
+const downloadImage = async () => {
+  if (uploadedFiles.value.length === 0) {
+    console.warn('请先上传图片')
+    return
+  }
+  
   const node = document.getElementById('display-section')
-  toPng(node)
-    .then((dataUrl) => {
-      const link = document.createElement('a')
-      link.download = `${MemeName.value}展示图.png`
-      link.href = dataUrl
-      link.click()
+  if (!node) {
+    console.error('未找到预览元素')
+    return
+  }
+  
+  try {
+    // 临时移除缩放，确保生成原始尺寸的图像
+    const originalTransform = node.style.transform
+    node.style.transform = 'scale(1)'
+    node.style.width = `${PREVIEW_WIDTH}px`
+    
+    const dataUrl = await toPng(node, {
+      width: PREVIEW_WIDTH, // 固定宽度800px
+      pixelRatio: 2, // 高清输出
+      backgroundColor: 'white' // 确保背景色
     })
-    .catch((error) => {
-      console.error('oops, something went wrong!', error)
-    });
+    
+    // 恢复原始样式
+    node.style.transform = originalTransform
+    node.style.width = ''
+    
+    const link = document.createElement('a')
+    link.download = `${MemeName.value}展示图.png`
+    link.href = dataUrl
+    link.click()
+    
+  } catch (error) {
+    console.error('生成图片失败:', error)
+    // 恢复样式，即使出错也要确保界面正常
+    node.style.transform = contentStyle.value.transform
+    node.style.width = contentStyle.value.width
+  }
 }
 </script>
 <style scoped>
@@ -229,5 +362,14 @@ const downloadImage = () => {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.preview-wrapper {
+  display: inline-block; /* 使用inline-block以适应内容尺寸 */
+}
+
+.preview-content {
+  display: block;
+  /* transform缩放不会改变布局空间，需要手动调整 */
 }
 </style>


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the theme editor page and supporting components, focusing on usability, maintainability, and scalability. The most significant changes include a major redesign of the control panel UI, introduction of an `ImageListManager` component for image uploads, enhanced watermark logic, and dependency updates for better drag-and-drop support. These changes collectively streamline the user experience and prepare the codebase for more modular image management.

**UI and UX Improvements:**

* The left-side control panel in `theme1.vue` is completely redesigned for better organization and clarity, grouping settings into collapsible sections for basic info, style, watermark, and QR code. The "Generate Display Image" button is now more prominent and only enabled when images are uploaded. [[1]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bL3-R33) [[2]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bL50-R193)
* The preview area now uses a fixed 800px width and dynamically scales to fit the container, improving cross-device consistency and visual fidelity.

**Component Refactoring and New Features:**

* The image upload and management logic is moved to a new `ImageListManager` component, which replaces the previous inline upload controls. This sets the stage for more advanced image handling features and cleaner code separation. [[1]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bL3-R33) [[2]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bR206)
* Watermark logic in `WaterMark.vue` is refactored to use the container size rather than the window size, resulting in more accurate watermark placement and responsiveness. [[1]](diffhunk://#diff-573d6eee6b83e58b33559056bfb4f109e155d558740867a70e45cb463fb758b7L18-R19) [[2]](diffhunk://#diff-573d6eee6b83e58b33559056bfb4f109e155d558740867a70e45cb463fb758b7L52-R63)
* The watermark and title photo logic is streamlined, with the store now tracking a `currentTitlePhoto` and the upload handler simplified to support only watermark uploads from the control panel. [[1]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bR206) [[2]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bL200-R290)

**Dependency and Build Updates:**

* Adds `sortablejs` and `@types/sortablejs` to `package.json` and updates `pnpm-lock.yaml` accordingly, preparing the project for drag-and-drop image reordering and better type safety. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R13) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R25) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14-R22) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR50-R52) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR600-R602) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1491-R1493) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2195-R2196) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2346-R2368) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3105-R3106)

**Minor Layout and Styling Adjustments:**

* Adjusts the minimum height logic in `DisplayContent.vue` for improved flexibility and visual consistency.

**References:**  
[[1]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bL3-R33) [[2]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bL50-R193) [[3]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bR220-R281) [[4]](diffhunk://#diff-8c3da67ef4807f9495a1da7fac2ad8502fca41a624238f3569adb0653801843bR206) [[5]](diffhunk://#diff-573d6eee6b83e58b33559056bfb4f109e155d558740867a70e45cb463fb758b7L18-R19) [[6]](diffhunk://#diff-573d6eee6b83e58b33559056bfb4f109e155d558740867a70e45cb463fb758b7L52-R63) [[7]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R13) [[8]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R25) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14-R22)